### PR TITLE
[FE/ auth] error: token 파싱 유틸 토큰이 add되어있지 않았었음

### DIFF
--- a/src/frontend/util/parseToken.ts
+++ b/src/frontend/util/parseToken.ts
@@ -1,0 +1,7 @@
+export function parseToken(jwtToken: string) {
+  //[refer]: jwt decode하는 코드 | 출처: https://archijude.tistory.com/432
+  const base64Payload = jwtToken.split('.')[1]; //value 0 -> header, 1 -> payload, 2 -> VERIFY SIGNATURE
+  const payload = Buffer.from(base64Payload, 'base64');
+  const result = JSON.parse(payload.toString());
+  return result;
+}


### PR DESCRIPTION
깃 실수로 util 파일이 이전 pr merge에서 제외되어있었습니다.
추가시켜서 merge하기 위해 PR 올립니다. 

+hotfix를 사용하지 않은 이유는 auth와 관련된 파일이기 때문입니다.