### PR TITLE
[FE/메인] 메인 컨텐츠

### DIFF
--- a/src/frontend/components/molecules/BigGameSlide.tsx
+++ b/src/frontend/components/molecules/BigGameSlide.tsx
@@ -4,8 +4,24 @@ import Image from 'next/image';
 import Text from 'components/atoms/Text';
 import { localePrice } from 'util/localeString';
 
-interface SlideProps {
-  image: JSX.Element | typeof Image;
+// 이거 다 안써도 되나?
+export interface gameInfo {
+  category_list: string[];
+  description_snippet: string;
+  download_count: number;
+  id: number;
+  image: {
+    main: string;
+    sub: string[];
+  };
+  name: string;
+  os_list: string[];
+  price: number;
+  sale: number;
+  video?: {
+    main: string;
+    sub: string[];
+  };
 }
 
 const SlideWrapper = styled.div`
@@ -15,6 +31,10 @@ const SlideWrapper = styled.div`
   border-radius: 10px;
 `;
 
-export default function BigGameSlide(props: SlideProps) {
-  return <SlideWrapper>{props.image}</SlideWrapper>;
+export default function BigGameSlide(props: gameInfo) {
+  return (
+    <SlideWrapper>
+      <Image src={props.image.main}></Image>
+    </SlideWrapper>
+  );
 }

--- a/src/frontend/components/molecules/BigGameSlide.tsx
+++ b/src/frontend/components/molecules/BigGameSlide.tsx
@@ -5,7 +5,7 @@ import Text from 'components/atoms/Text';
 import { localePrice } from 'util/localeString';
 
 // 이거 다 안써도 되나?
-export interface gameInfo {
+export interface IGameInfo {
   category_list: string[];
   description_snippet: string;
   download_count: number;
@@ -26,15 +26,16 @@ export interface gameInfo {
 
 const SlideWrapper = styled.div`
   display: block;
-  overflow: hidden;
   height: calc(100vw / 3);
   border-radius: 10px;
+  position: relative;
+  overflow: hidden;
 `;
 
-export default function BigGameSlide(props: gameInfo) {
+export default function BigGameSlide(props: IGameInfo) {
   return (
     <SlideWrapper>
-      <Image src={props.image.main}></Image>
+      <Image src={props.image.main} layout="fill" objectFit="cover"></Image>
     </SlideWrapper>
   );
 }

--- a/src/frontend/components/molecules/GameSlide.tsx
+++ b/src/frontend/components/molecules/GameSlide.tsx
@@ -4,11 +4,23 @@ import Image from 'next/image';
 import Text from 'components/atoms/Text';
 import { localePrice } from 'util/localeString';
 
-interface SlideProps {
-  image: JSX.Element | typeof Image;
-  info: {
-    name: string;
-    price: number;
+// 이거 다 안써도 되나?
+export interface gameInfo {
+  category_list: string[];
+  description_snippet: string;
+  download_count: number;
+  id: number;
+  image: {
+    main: string;
+    sub: string[];
+  };
+  name: string;
+  os_list: string[];
+  price: number;
+  sale: number;
+  video?: {
+    main: string;
+    sub: string[];
   };
 }
 
@@ -40,13 +52,15 @@ const InfoSection = styled.div`
   border-radius: 0 0 10px 10px;
 `;
 
-export default function GameSlide(props: SlideProps) {
+export default function GameSlide(props: gameInfo) {
   return (
     <SlideWrapper>
-      <ImageSection>{props.image}</ImageSection>
+      <ImageSection>
+        <Image src={props.image.main}></Image>
+      </ImageSection>
       <InfoSection>
-        <Text types="small">{props.info.name}</Text>
-        <Text types="tiny">{`${localePrice(props.info.price, 'KR')}`}</Text>
+        <Text types="small">{props.name}</Text>
+        <Text types="tiny">{`${localePrice(props.price, 'KR')}`}</Text>
       </InfoSection>
     </SlideWrapper>
   );

--- a/src/frontend/components/molecules/GameSlide.tsx
+++ b/src/frontend/components/molecules/GameSlide.tsx
@@ -43,7 +43,7 @@ const ImageSection = styled.div`
 `;
 
 const InfoSection = styled.div`
-  height: 30%;
+  height: 70px;
   background: ${(props) => props.theme.colors.secondaryBg};
   padding: 0.5rem;
   display: flex;

--- a/src/frontend/components/molecules/GameSlide.tsx
+++ b/src/frontend/components/molecules/GameSlide.tsx
@@ -5,7 +5,7 @@ import Text from 'components/atoms/Text';
 import { localePrice } from 'util/localeString';
 
 // 이거 다 안써도 되나?
-export interface gameInfo {
+export interface IGameInfo {
   category_list: string[];
   description_snippet: string;
   download_count: number;
@@ -26,7 +26,7 @@ export interface gameInfo {
 
 const SlideWrapper = styled.div`
   width: 100%;
-  height: 80%;
+  min-height: 250px;
   padding: 1rem 0 1rem 1rem;
   display: flex;
   flex-direction: column;
@@ -35,28 +35,30 @@ const SlideWrapper = styled.div`
 
 const ImageSection = styled.div`
   width: 100%;
+  height: 80%;
   flex: 1;
   overflow: hidden;
   border-radius: 10px 10px 0 0;
+  position: relative;
 `;
 
 const InfoSection = styled.div`
   height: 30%;
   background: ${(props) => props.theme.colors.secondaryBg};
-  padding: 1%;
+  padding: 0.5rem;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
   color: black;
-  padding-left: 5%;
   border-radius: 0 0 10px 10px;
+  line-height: normal;
 `;
 
-export default function GameSlide(props: gameInfo) {
+export default function GameSlide(props: IGameInfo) {
   return (
     <SlideWrapper>
       <ImageSection>
-        <Image src={props.image.main}></Image>
+        <Image src={props.image.main} layout="fill" objectFit="cover"></Image>
       </ImageSection>
       <InfoSection>
         <Text types="small">{props.name}</Text>

--- a/src/frontend/components/organisms/BigCarousel.tsx
+++ b/src/frontend/components/organisms/BigCarousel.tsx
@@ -40,7 +40,7 @@ export default function BigCarouselComponent(props: CarouselProps) {
     <CustomCarousel
       responsive={responsive}
       ssr={true} // means to render carousel on server-side.
-      // autoPlay={true}
+      autoPlay={true}
       autoPlaySpeed={3000}
       infinite
       showDots={true}

--- a/src/frontend/components/organisms/BigCarousel.tsx
+++ b/src/frontend/components/organisms/BigCarousel.tsx
@@ -40,8 +40,8 @@ export default function BigCarouselComponent(props: CarouselProps) {
     <CustomCarousel
       responsive={responsive}
       ssr={true} // means to render carousel on server-side.
-      autoPlay={true}
-      autoPlaySpeed={2000}
+      // autoPlay={true}
+      autoPlaySpeed={3000}
       infinite
       showDots={true}
       arrows={false}

--- a/src/frontend/components/organisms/Carousel.tsx
+++ b/src/frontend/components/organisms/Carousel.tsx
@@ -12,7 +12,7 @@ interface CarouselProps {
 const CustomCarousel = styled(Carousel)`
   width: 80%;
   margin: 0 auto;
-  
+
   .react-multiple-carousel__arrow--right {
     margin-right: -3%;
     margin-bottom: 8%;
@@ -45,8 +45,8 @@ export default function CarouselComponent(props: CarouselProps) {
     <CustomCarousel
       responsive={responsive}
       ssr={true} // means to render carousel on server-side.
-      autoPlay={true}
-      autoPlaySpeed={2000}
+      // autoPlay={true}
+      autoPlaySpeed={3000}
       infinite
       removeArrowOnDeviceType={['small']}
     >

--- a/src/frontend/components/organisms/Carousel.tsx
+++ b/src/frontend/components/organisms/Carousel.tsx
@@ -45,7 +45,7 @@ export default function CarouselComponent(props: CarouselProps) {
     <CustomCarousel
       responsive={responsive}
       ssr={true} // means to render carousel on server-side.
-      // autoPlay={true}
+      autoPlay={true}
       autoPlaySpeed={3000}
       infinite
       removeArrowOnDeviceType={['small']}

--- a/src/frontend/pages/api/game/api.ts
+++ b/src/frontend/pages/api/game/api.ts
@@ -35,6 +35,12 @@ export async function getGameAPI(param: IGetGameReqType) {
   return response.data;
 }
 
+export async function getGameListAPI(query: string) {
+  const response = await axios.get<IResType>(`${process.env.NEXT_PUBLIC_BASE_URL_STORE}/store/games/?${query}`);
+
+  return response.data;
+}
+
 export async function purchaseGameAPI(param: IPurchaseGameReqType[]) {
   const response = await axiosClient.post<IResType>(`${process.env.NEXT_PUBLIC_BASE_URL_STORE}/payment/cart/purchase`, {
     games: param,

--- a/src/frontend/pages/api/game/api.ts
+++ b/src/frontend/pages/api/game/api.ts
@@ -36,7 +36,7 @@ export async function getGameAPI(param: IGetGameReqType) {
 }
 
 export async function getGameListAPI(query: string) {
-  const response = await axios.get<IResType>(`${process.env.NEXT_PUBLIC_BASE_URL_STORE}/store/games/?${query}`);
+  const response = await axios.get<IResType>(`${process.env.NEXT_PUBLIC_BASE_URL_STORE}/store/games?${query}`);
 
   return response.data;
 }

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -19,6 +19,10 @@ const MainWrapper = styled.div`
   height: 100%;
 `;
 
+const Title = styled(Text)`
+  margin: 3rem 0 0 3rem;
+`;
+
 const CarouselSection = styled.div`
   width: calc(100vw - 250px);
 `;
@@ -43,7 +47,7 @@ const Main: NextPage = () => {
   return (
     <MainWrapper>
       <CarouselSection>
-        <Text types={'large'}>인기 게임</Text>
+        <Title types={'large'}>인기 게임</Title>
         <CarouselBox>
           <BigCarouselComponent
             slides={rankGames.map((data) => {
@@ -51,7 +55,7 @@ const Main: NextPage = () => {
             })}
           ></BigCarouselComponent>
         </CarouselBox>
-        <Text types={'large'}>할인중인 게임</Text>
+        <Title types={'large'}>할인중인 게임</Title>
         <CarouselBox>
           <CarouselComponent
             slides={saleGames.map((data) => {

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -10,6 +10,7 @@ import gameImage from 'public/game.png';
 import Image from 'next/image';
 import { getGameListAPI } from './api/game/api';
 import Text from 'components/atoms/Text';
+import { IGameInfo } from 'components/molecules/GameSlide';
 
 const MainWrapper = styled.div`
   display: flex;
@@ -27,56 +28,37 @@ const CarouselBox = styled.div`
 `;
 
 const Main: NextPage = () => {
-  const [rankGames, setRankGames] = useState([]); // 다운로드 높은 게임들
-  const [saleGames, setSaleGames] = useState([]); // 할인률 높은 게임들
+  const [rankGames, setRankGames] = useState([] as IGameInfo[]); // 다운로드 높은 게임들
+  const [saleGames, setSaleGames] = useState([] as IGameInfo[]); // 할인률 높은 게임들
 
   const getGames = async () => {
-    setRankGames((await getGameListAPI('category=ALL&page=1&size=5&sort=desc')).data.game_list);
-    setRankGames((await getGameListAPI('category=ALL&page=1&size=5&sort=desc')).data.game_list);
-    console.log(rankGames);
+    setRankGames((await getGameListAPI('category=ALL&page=1&size=5&sort=download_count,desc')).data.game_list);
+    setSaleGames((await getGameListAPI('category=ALL&page=1&size=5&sort=sale,desc')).data.game_list);
   };
 
   useEffect(() => {
     getGames();
-  });
+  }, []);
 
   return (
     <MainWrapper>
       <CarouselSection>
         <Text types={'large'}>인기 게임</Text>
-        {/* <CarouselBox>
+        <CarouselBox>
           <BigCarouselComponent
-            slides={mockData.map((data) => {
-              return (
-                <BigGameSlide
-                  key={data.id}
-                  image={<Image src={gameImage} layout="fill" objectFit="cover" />}
-                  info={{
-                    name: data.name,
-                    price: data.price.kr,
-                  }}
-                ></BigGameSlide>
-              );
+            slides={rankGames.map((data) => {
+              return <BigGameSlide key={data.id} {...data}></BigGameSlide>;
             })}
           ></BigCarouselComponent>
         </CarouselBox>
-              <Text types={'large'}>할인중인 게임</Text>
+        <Text types={'large'}>할인중인 게임</Text>
         <CarouselBox>
           <CarouselComponent
-            slides={mockData.map((data) => {
-              return (
-                <GameSlide
-                  key={data.id}
-                  image={<Image src={gameImage2} layout="responsive" />}
-                  info={{
-                    name: data.name,
-                    price: data.price['KR'],
-                  }}
-                ></GameSlide>
-              );
+            slides={saleGames.map((data) => {
+              return <GameSlide key={data.id} {...data}></GameSlide>;
             })}
           ></CarouselComponent>
-        </CarouselBox> */}
+        </CarouselBox>
       </CarouselSection>
     </MainWrapper>
   );

--- a/src/frontend/pages/index.tsx
+++ b/src/frontend/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { NextPage } from 'next';
 import styled from 'styled-components';
 import CarouselComponent from 'components/organisms/Carousel';
@@ -8,6 +8,8 @@ import BigGameSlide from 'components/molecules/BigGameSlide';
 import gameImage2 from 'public/game2.jpg';
 import gameImage from 'public/game.png';
 import Image from 'next/image';
+import { getGameListAPI } from './api/game/api';
+import Text from 'components/atoms/Text';
 
 const MainWrapper = styled.div`
   display: flex;
@@ -25,10 +27,24 @@ const CarouselBox = styled.div`
 `;
 
 const Main: NextPage = () => {
+  const [rankGames, setRankGames] = useState([]); // 다운로드 높은 게임들
+  const [saleGames, setSaleGames] = useState([]); // 할인률 높은 게임들
+
+  const getGames = async () => {
+    setRankGames((await getGameListAPI('category=ALL&page=1&size=5&sort=desc')).data.game_list);
+    setRankGames((await getGameListAPI('category=ALL&page=1&size=5&sort=desc')).data.game_list);
+    console.log(rankGames);
+  };
+
+  useEffect(() => {
+    getGames();
+  });
+
   return (
     <MainWrapper>
       <CarouselSection>
-        <CarouselBox>
+        <Text types={'large'}>인기 게임</Text>
+        {/* <CarouselBox>
           <BigCarouselComponent
             slides={mockData.map((data) => {
               return (
@@ -44,6 +60,7 @@ const Main: NextPage = () => {
             })}
           ></BigCarouselComponent>
         </CarouselBox>
+              <Text types={'large'}>할인중인 게임</Text>
         <CarouselBox>
           <CarouselComponent
             slides={mockData.map((data) => {
@@ -59,7 +76,7 @@ const Main: NextPage = () => {
               );
             })}
           ></CarouselComponent>
-        </CarouselBox>
+        </CarouselBox> */}
       </CarouselSection>
     </MainWrapper>
   );


### PR DESCRIPTION
### **TO DO**

### **뷰**
- [x] carousel 반응형
- 웹 
<img width="990" alt="스크린샷 2022-02-25 오전 9 42 43" src="https://user-images.githubusercontent.com/24283401/155631623-c4680bbc-ec26-4b46-9c49-808bfab22938.png">
- 태블릿
<img width="665" alt="스크린샷 2022-02-25 오전 9 43 05" src="https://user-images.githubusercontent.com/24283401/155631658-5d01e0c5-2da5-4bba-b9fa-d6e7b5cbb275.png">
- 모바일
<img width="438" alt="스크린샷 2022-02-25 오전 9 43 24" src="https://user-images.githubusercontent.com/24283401/155631747-f74fc04e-48de-4345-ae16-bc01f93d5f28.png">

### **통신**
- 게임 리스트 가져오기 
  - [x] mockData 오류 해결 
  - [x] 인기 게임 (다운로드 높은 순위)
  - [x] 할인중인 게임


### **+)**
- 일단 통신 코드 작성까지 완료했고, 테스팅은 다음주에 진행하겠습니다.
- 다른 서버랑 관련있어서 아직 개발 못한 부분은 주석에 TODO로 남겨두었습니다.

@ummaeha  
메인 페이지에  carousel 사이에 GameInfo 이용해서 다른 게임 컨텐츠 넣어주면 좋을 것 같아요!

### **PREVIEW**
https://user-images.githubusercontent.com/24283401/153577081-66df960a-9d18-4796-9807-f11cb0d150a3.mov


